### PR TITLE
Fix test + content length handling

### DIFF
--- a/t/00-Blob.t
+++ b/t/00-Blob.t
@@ -15,6 +15,7 @@ if ($ENV{AUTOMATED_TESTING}) {
 
 my $account_name = $ENV{TESTING_AZURE_ACCOUNT_NAME};
 my $primary_access_key = $ENV{TESTING_AZURE_ACCESS_KEY};
+my $api_version = $ENV{TESTING_AZURE_API_VERSION} // '2014-02-14';
 
 diag 'Please provide an account name of Windows Azure Blob Storage via TESTING_AZURE_ACCOUNT_NAME'
     unless $account_name;
@@ -39,6 +40,7 @@ my $client = Net::Azure::StorageClient->new(
                                              type => 'Blob',
                                              account_name => $account_name,
                                              primary_access_key => $primary_access_key,
+                                             api_version => $api_version,
                                             );
 
 isa_ok $client, 'Net::Azure::StorageClient::Blob';


### PR DESCRIPTION
A couple of fixes for issues discovered while testing against the Azure Blob Service.

- Make the existing t/00-Blob.t test pass. For versions older than 2014-02-14, setting TESTING_AZURE_ACCOUNT_NAME and TESTING_AZURE_ACCESS_KEY to something valid and running the test currently produces the below (newer versions work ok):
```
<Error><Code>InvalidHeaderValue</Code><Message>The value for one of the HTTP headers is not in the correct format.\nRequestId:a32c921b-901e-005f-5fbd-197bd0000000\nTim
e:2021-03-15T17:08:07.8331777Z</Message><HeaderName>x-ms-version</HeaderName><HeaderValue>2012-02-12</HeaderValue></Error>
```
- Make Content-Length handling compatible with newer api versions. Using a recent version (e.g. 2020-06-12) appears to require a Content-Length header in all cases - if it's missing, the API produces errors like this:
```
"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"http://www.w3.org/TR/html4/strict.dtd\">\r\n<HTML><HEAD><TITLE>Length Required</TITLE>\r\n<META HTTP-EQUIV=\"Content-Type\" Content=\"text/html; charset=us-ascii\"></HE
AD>\r\n<BODY><h2>Length Required</h2>\r\n<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>\r\n</BODY></HTML>\r\n"
```
If the Content-Length header is set manually to zero in an attempt to work around, the client uses the value of zero in the string to sign, producing this:
```
<Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.\nRequestId:41471aaa-a01e-0057-2bab-1960a3000000\nTime:2021-03-15T15:00:21.3770894Z</Message><AuthenticationErrorDetail>The MAC signature found in the HTTP request 'HKpXkOxwCxK6h4m7bQsNyEUYatO0HhjI431pOHAxadQ=' is not the same as any computed signature. Server used following string to sign: 'PUT\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:Mon, 15 Mar 2021 15:00:21 GMT\nx-ms-version:2020-06-12\n/wdh1/foo-container\nrestype:container'.</AuthenticationErrorDetail></Error>
```
Patching to use the empty string for the newer versions instead (per the docs at https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key) appears to fix.

HTH